### PR TITLE
Improve map click and map long click gesture handling on iOS

### DIFF
--- a/ios/Classes/NaxaLibreListeners.swift
+++ b/ios/Classes/NaxaLibreListeners.swift
@@ -9,15 +9,6 @@ import Foundation
 import Flutter
 import MapLibre
 
-/**
- * NaxaLibreListeners - Handles map interactions using MapLibre's built-in gesture system
- *
- * This implementation follows the documented approach by:
- * - Using built-in gesture recognizers for annotation selection
- * - Adding fallback gesture recognizers that only fire when built-in gestures fail
- * - Leveraging MLNMapViewDelegate methods for annotation interactions
- * - Allowing custom gestures to work alongside MapLibre's gesture system
- */
 class NaxaLibreListeners: NSObject, MLNMapViewDelegate, UIGestureRecognizerDelegate {
     private let binaryMessenger: FlutterBinaryMessenger
     private let libreView: MLNMapView

--- a/ios/Classes/Parsers/SourceArgsParser.swift
+++ b/ios/Classes/Parsers/SourceArgsParser.swift
@@ -105,7 +105,7 @@ class SourceArgsParser {
         if let url = url, let tileURL = URL(string: url) {
             return MLNVectorTileSource(
                 identifier: sourceId,
-                configurationURL: tileURL,
+                configurationURL: tileURL
             )
         }
         


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [] Feature
- [] Bug Fix
- [x] Optimization
- [] Documentation Update

## Description
Currently, long click feels a bit off on iOS. It doesn't fire until you lift your finger, or when you've been keeping it pressed for some time. As an iOS user, I would expect long click event to fire as soon as it's not considered a "simple" click. This MR aims to bring the iOS version on par with the Android version in terms of user experience.

Please note, it's a draft because while it may work as expected for me, I'm not really sure whether it's the most efficient way to do it. Also renamings are just AI being AI. 

## Related Tickets & Documents

- Related Issue #
- Closes #
